### PR TITLE
Ajusta título do site para celulares

### DIFF
--- a/_src/styles.css
+++ b/_src/styles.css
@@ -10,3 +10,15 @@
   font-weight: 500;
 }
 
+@media only screen and (max-width: 479px){
+    .navbar-brand {
+        float: none;
+        padding: 0.5em;
+    }
+
+    .navbar-author {
+        display: inline-block;
+        margin-left: 0;
+        padding: 0.5em;
+    }
+}


### PR DESCRIPTION
O  título do site estava bagunçando o cabeçalho inteiro quando acessado em celulares com resolução menores. Ajustei o título de acordo.